### PR TITLE
Volatile fixes 20160520-01 (closes alces-software/packager-base#160, closes alces-software/packager-base#159)

### DIFF
--- a/pkg/apps/cufflinks/2.2.2.20150701/metadata.yml
+++ b/pkg/apps/cufflinks/2.2.2.20150701/metadata.yml
@@ -12,7 +12,7 @@
   many reads support each one, taking into account biases in library
   preparation protocols.
 :group: Bioinformatics
-:requirements: 
+:requirements:
   :runtime:
     - libs/boost <= 1.55.0
     - apps/samtools ~> 0.1.18
@@ -22,7 +22,7 @@
     - libs/eigen ~> 3.0
 :changelog: |
  * Tue May  3 2016 - Ruan G. Ellis <ruan.ellis@alces-software.com>
-    - Updated distro dependencies for EL 
+    - Updated distro dependencies for EL
  * Thu Jul 30 2015 - Mark J. Titorenko <mark.titorenko@alces-software.com>
     - Updated to latest prerelease 2.2.2 2015-07-01
   * Tue May  5 2015 Mark J. Titorenko <mark.titorenko@alces-software.com>

--- a/pkg/apps/memesuite/4.11.1/metadata.yml
+++ b/pkg/apps/memesuite/4.11.1/metadata.yml
@@ -23,6 +23,8 @@
   ChIP-seq and other large datasets (MEME-ChIP).
 :group: Bioinformatics
 :changelog: |
+  * Thu May 19 2016 Mark J. Titorenko <mark.titorenko@alces-software.com>
+    - Prepend to PERL5LIB during compile, don't override entirely
   * Wed Apr 20 2016 Mark J. Titorenko <mark.titorenko@alces-software.com>
     - Updated to latest v4.11.1
   * Tue Sep  2 2014 Mark J. Titorenko <mark.titorenko@alces-software.com>
@@ -66,7 +68,7 @@
   - XML::Simple
   - XML::Parser::Expat
 :compile: |
-  export PERL5LIB="<%= dest_dir %>/perl/lib/perl5"
+  export PERL5LIB="<%= dest_dir %>/perl/lib/perl5:$PERL5LIB"
   export PERL_CPANM_OPT="-l <%= dest_dir %>/perl -n"
   for a in <%= package.perl_reqs.join(' ') %>; do
     cpanm $a <%= redirect(:cpanm) %>

--- a/pkg/apps/nucleoatac/0.3.1/metadata.yml
+++ b/pkg/apps/nucleoatac/0.3.1/metadata.yml
@@ -23,82 +23,35 @@
 :version: '0.3.1'
 :compilers:
   gcc:
-:variants:
-  default:
-    :description: "Builds for Python 2.7.x series"
-    :python_bin: python
-    :python_libdir: python2.7
-    :requirements:
-      :tool:
-        - apps/setuptools
-      :build:
-        - apps/python ~> 2.7.0
-        - apps/cython >= 0.22
-        - libs/numpy >= 0.9.1
-        - libs/scipy == 0.17.0
-        - libs/pysam >= 0.8.1
-        - libs/matplotlib
-      :runtime:
-        - apps/python ~> 2.7.0
-        - apps/cython >= 0.22
-        - libs/numpy >= 0.9.1
-        - libs/scipy == 0.17.0
-        - libs/pysam >= 0.8.1
-        - libs/matplotlib
-  python3:
-    :description: "Builds for Python 3.3.x series"
-    :python_bin: python3
-    :python_libdir: python3.3
-    :requirements:
-      :tool:
-        - apps/setuptools_python3
-      :build:
-        - apps/python3 ~> 3.3.0
-        - apps/cython_python3 >= 0.22
-        - libs/numpy_python3 >= 0.9.1
-        - libs/scipy_python3 = 0.17.0
-        - libs/pysam_python3 >= 0.8.1
-        - libs/matplotlib_python3
-      :runtime:
-        - apps/python3 ~> 3.3.0
-        - apps/cython_python3 >= 0.22
-        - libs/numpy_python3 >= 0.9.1
-        - libs/scipy_python3 = 0.17.0
-        - libs/pysam_python3 >= 0.8.1
-        - libs/matplotlib_python3
-  python34:
-    :description: "Builds for Python 3.4.x series"
-    :python_bin: python3
-    :python_libdir: python3.4
-    :requirements:
-      :tool:
-        - apps/setuptools_python34
-      :build:
-        - apps/python34 ~> 3.4.0
-        - apps/cython_python34 >= 0.22
-        - libs/numpy_python34 >= 0.9.1
-        - libs/scipy_python34 >= 0.16.0
-        - libs/pysam_python34 >= 0.8.1
-        - libs/matplotlib_python34
-      :runtime:
-        - apps/python34 ~> 3.4.0
-        - apps/cython_python34 >= 0.22
-        - libs/numpy_python34 >= 0.9.1
-        - libs/scipy_python34 >= 0.16.0
-        - libs/pysam_python34 >= 0.8.1
-        - libs/matplotlib_python34
+:requirements:
+  :tool:
+    - apps/setuptools
+  :build:
+    - apps/python ~> 2.7.0
+    - apps/cython >= 0.22
+    - libs/numpy >= 0.9.1
+    - libs/scipy == 0.17.0
+    - libs/pysam >= 0.8.1
+    - libs/matplotlib
+  :runtime:
+    - apps/python ~> 2.7.0
+    - apps/cython >= 0.22
+    - libs/numpy >= 0.9.1
+    - libs/scipy == 0.17.0
+    - libs/pysam >= 0.8.1
+    - libs/matplotlib
 :compile: |
   export PYTHONDONTWRITEBYTECODE=true
-  <%= variant[:python_bin] %> setup.py build <%= redirect(:build) %>
+  python setup.py build <%= redirect(:build) %>
 :install: |
   export PYTHONDONTWRITEBYTECODE=true
-  PYTHONDEPSDIR=<%= dest_dir %>/python/lib/<%= variant[:python_libdir ] %>/site-packages
+  PYTHONDEPSDIR=<%= dest_dir %>/python/lib/python2.7/site-packages
   PYTHONPATH=$PYTHONDEPSDIR:$PYTHONPATH
   mkdir -p $PYTHONDEPSDIR
-  <%= variant[:python_bin] %> setup.py install --prefix <%= dest_dir %>/python <%= redirect(:install) %>
+  python setup.py install --prefix <%= dest_dir %>/python <%= redirect(:install) %>
 :module: |
   setenv ${appcaps}DIR ${appdir}
   setenv ${appcaps}BIN ${appdir}/python/bin
 
-  prepend-path PYTHONPATH ${appdir}/python/lib/<%= variant[:python_libdir] %>/site-packages
+  prepend-path PYTHONPATH ${appdir}/python/lib/python2.7/site-packages
   prepend-path PATH ${appdir}/python/bin

--- a/pkg/libs/scipy/0.17.0/metadata.yml
+++ b/pkg/libs/scipy/0.17.0/metadata.yml
@@ -16,6 +16,8 @@
 :type: libs
 :group: Mathematics
 :changelog: |
+  * Sun May 15 2016 - Ruan G. Ellis <ruan.ellis@alces-software.com>
+    - Updated Metadata to re-compile against NumPy v1.10.4
   * Wed Mar 30 2016 - Mark J. Titorenko <mark.titorenko@alces-software.com>
     - Use patchelf to remove hardcoded ATLAS library paths
     - Added distro dependencies


### PR DESCRIPTION
Remove non-functional python3 and python34 nucleoatac variants.
